### PR TITLE
Add basic vendor frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Bringing fast, reliable delivery from rural areas to nearby towns — built with
 - GitHub + VS Code
 
 ## 🚀 How to Run It
-1. Clone the repo  
-2. Install dependencies  
-3. Run with `json-server --watch db.json`  
-4. Launch frontend via `Live Server`
+1. Clone the repo
+2. Install dependencies
+3. Start the mock API with `json-server --watch db.json`
+4. Open `index.html` in your browser (or use Live Server)
 
 ## 📜 License
 Open source — use it, remix it, empower your people.

--- a/db.json
+++ b/db.json
@@ -1,0 +1,9 @@
+
+{
+  "vendors": [
+    { "id": 1, "name": "Hari Grocery", "location": "Lamahatta" }
+  ],
+  "orders": [
+    { "id": 1, "vendorId": 1, "item": "Potatoes", "quantity": 5 }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Village Delivery App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Village Delivery App</h1>
+    </header>
+    <main>
+        <section id="vendors">
+            <h2>Vendors</h2>
+            <ul id="vendorList"></ul>
+        </section>
+        <section id="addVendor">
+            <h2>Add Vendor</h2>
+            <form id="vendorForm">
+                <input type="text" id="name" placeholder="Vendor Name" required>
+                <input type="text" id="location" placeholder="Location" required>
+                <button type="submit">Add</button>
+            </form>
+        </section>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,33 @@
+const API_URL = 'http://localhost:3000/vendors';
+
+async function loadVendors() {
+    const res = await fetch(API_URL);
+    const vendors = await res.json();
+    const list = document.getElementById('vendorList');
+    list.innerHTML = '';
+    vendors.forEach(v => {
+        const li = document.createElement('li');
+        li.textContent = `${v.name} - ${v.location}`;
+        list.appendChild(li);
+    });
+}
+
+document.getElementById('vendorForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const name = document.getElementById('name').value.trim();
+    const location = document.getElementById('location').value.trim();
+    if (!name || !location) return;
+
+    await fetch(API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ name, location })
+    });
+
+    document.getElementById('vendorForm').reset();
+    loadVendors();
+});
+
+window.addEventListener('DOMContentLoaded', loadVendors);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,50 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header {
+    background-color: #2c3e50;
+    color: white;
+    padding: 1rem;
+    text-align: center;
+}
+
+main {
+    flex: 1;
+    padding: 1rem;
+}
+
+section {
+    margin-bottom: 2rem;
+}
+
+#vendorList {
+    list-style: none;
+    padding: 0;
+}
+
+#vendorList li {
+    background: #ecf0f1;
+    margin-bottom: .5rem;
+    padding: .5rem;
+    border-radius: 4px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    max-width: 300px;
+}
+
+@media (min-width: 600px) {
+    main {
+        max-width: 800px;
+        margin: 0 auto;
+    }
+}


### PR DESCRIPTION
## Summary
- add mock database
- add simple frontend interface
- allow adding vendors via form
- update instructions for running mock API

## Testing
- `json-server --watch db.json --port 3000` *(fails: serves & prints help to confirm)*

------
https://chatgpt.com/codex/tasks/task_e_68413455d9248326a36f7efb2dc58ba7